### PR TITLE
Fixed bugs in tournament module

### DIFF
--- a/frontend/i18n.ts
+++ b/frontend/i18n.ts
@@ -1,10 +1,10 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
-import enTranslation from "./locales/en.json"; 
+import enTranslation from "./locales/en.json";
 import fiTranslation from "./locales/fi.json";
 
-(async () => {
+const initI18n = async (): Promise<void> => {
   try {
     await i18n
       .use(initReactI18next) // passes i18n down to react-i18next
@@ -22,6 +22,9 @@ import fiTranslation from "./locales/fi.json";
   } catch (error) {
     console.error("Error initializing i18n:", error);
   }
-})();
+};
+
+// Explicitly call the async function
+void initI18n();
 
 export default i18n;

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -18,6 +18,7 @@
     "session_expired_message": "Session Expired: Your login session has expired for security reasons. Please log in again.",
     "tournament_info_not_found": "No data was found for this tournament. Close this to go back to the previous view.",
     "could_not_fetch_tournaments": "Could not fetch any tournaments",
+    "start_date_in_past_error": "Tournament has to start in the future",
     "dismiss": "Dismiss",
     "unexpected_error": "Unexpected error",
     "login_successful": "Login successful!",
@@ -183,7 +184,8 @@
     "start_date": "Start Date",
     "end_date": "End Date",
     "welcome": "Welcome to KendoApp! Here you can participate, host or follow tournaments!",
-    "winner": "WINNER"
+    "winner": "WINNER",
+    "cancelled": "CANCELLED, NOT ENOUGH PLAYERS"
   },
   "created_tournament": {
     "signed_up": "Signed up",
@@ -387,7 +389,7 @@
     "my_points": "My Points",
     "point_type": "Point Type",
     "points": "Points",
-    "created_tournaments": "Created tournaments" 
+    "created_tournaments": "Created tournaments"
   },
   "filtering": {
     "options": "Filtering options",

--- a/frontend/locales/fi.json
+++ b/frontend/locales/fi.json
@@ -14,6 +14,7 @@
     "sign_up_success": "Ilmoittautuduttiin onnistuneesti turnaukseen: ",
     "minimum_players_error": "Pelaajien vähimmäismäärä on ",
     "creations_success": "Turnaus {{name}} luotiin onnistuneesti",
+    "start_date_in_past_error": "Turnauksen on alettava tulevaisuudessa (vähintään 5 min)",
     "invalid_tournament_error": "Tämä turnaus vaikuttaa virheelliseltä. Ota yhteyttä {{organizerEmail}} saadaksesi lisätietoja tästä turnauksesta.",
     "session_expired_message": "Istunto vanhentunut: Kirjautumissessiosi on vanhentunut turvallisuussyistä. Kirjaudu sisään uudelleen.",
     "tournament_info_not_found": "Tälle turnaukselle ei löytynyt tietoja. Sulje tämä ja palaa edelliseen näkymään.",
@@ -97,7 +98,6 @@
     "withdraw_user_from_tournament": "Keskeytä pelaajan turnaus",
     "confirm_user_withdrawal": "Vahvista pelaajan turnauksen keskeyttäminen",
     "confirm_tournament_editing": "Vahvista turnauksen muokkaus"
-
   },
   "login_form": {
     "forgot_password": "Unohtuiko salasana?",
@@ -184,7 +184,8 @@
     "start_date": "Aloituspäivä",
     "end_date": "Päättymispäivä",
     "welcome": "Tervetuloa KendoAppiin! Voit osallistua, luoda tai seurata turnauksia sivustollamme!",
-    "winner": "VOITTAJA"
+    "winner": "VOITTAJA",
+    "cancelled": "PERUTTU, EI TARPEEKSI PELAAJIA"
   },
   "created_tournament": {
     "signed_up": "Ilmottautuneet",
@@ -382,7 +383,7 @@
     "confirmation_msg": "Oletko varma, että haluat keskeyttää pelaajan {{name}} turnauksen? Tätä valintaa ei voi perua."
   },
   "profile": {
-    "match":"Ottelu",
+    "match": "Ottelu",
     "profile_info": "Omat tiedot",
     "my_games": "Omat ottelut",
     "my_points": "Omat pisteet",

--- a/frontend/src/components/modules/GameInterface/GameInterface.tsx
+++ b/frontend/src/components/modules/GameInterface/GameInterface.tsx
@@ -848,6 +848,7 @@ const GameInterface: React.FC = () => {
                   handlePointShowing={handlePointShowing}
                   handleOpen={handleOpen}
                   handleClose={handleClose}
+                  gameStarted={matchInfo.startTimestamp !== undefined}
                 />
               )}
             <br></br>

--- a/frontend/src/components/modules/GameInterface/OfficialButtons.tsx
+++ b/frontend/src/components/modules/GameInterface/OfficialButtons.tsx
@@ -18,6 +18,7 @@ interface AddPointDialogProps {
   handlePointShowing: () => Promise<void>;
   handleOpen: (player: number) => void;
   handleClose: () => void;
+  gameStarted: boolean;
 }
 
 const OfficialButtons: React.FC<AddPointDialogProps> = ({
@@ -26,7 +27,8 @@ const OfficialButtons: React.FC<AddPointDialogProps> = ({
   handleRadioButtonClick,
   handlePointShowing,
   handleOpen,
-  handleClose
+  handleClose,
+  gameStarted
 }) => {
   const { t } = useTranslation();
 
@@ -38,6 +40,7 @@ const OfficialButtons: React.FC<AddPointDialogProps> = ({
             handleOpen(1);
           }}
           variant="contained"
+          disabled={!gameStarted}
         >
           {t("buttons.add_point_player_1")}
         </Button>
@@ -46,6 +49,7 @@ const OfficialButtons: React.FC<AddPointDialogProps> = ({
             handleOpen(2);
           }}
           variant="contained"
+          disabled={!gameStarted}
         >
           {t("buttons.add_point_player_2")}
         </Button>

--- a/frontend/src/components/modules/Tournaments/CreateTournament.tsx
+++ b/frontend/src/components/modules/Tournaments/CreateTournament.tsx
@@ -41,6 +41,7 @@ import routePaths from "routes/route-paths";
 const MIN_PLAYER_AMOUNT = 3;
 const MIN_GROUP_SIZE = 3;
 const now = dayjs();
+const minStartDate = now.add(5, "minutes");
 
 export interface CreateTournamentFormData {
   name: string;
@@ -67,7 +68,7 @@ export interface CreateTournamentFormData {
 const defaultValues: CreateTournamentFormData = {
   name: "",
   location: "",
-  startDate: now,
+  startDate: now.add(5, "minutes"),
   endDate: now.add(1, "week"),
   description: "",
   type: "Round Robin",
@@ -102,6 +103,11 @@ const CreateTournamentForm: React.FC = () => {
 
   const onSubmit = async (data: CreateTournamentFormData): Promise<void> => {
     try {
+      // Check if the start date is in the past
+      if (data.startDate.isBefore(minStartDate)) {
+        showToast(t("messages.start_date_in_past_error"), "error");
+        return;
+      }
       // Round dates to the nearest minute down
       const roundedStartDate = data.startDate.startOf("minute");
       const roundedEndDate = data.endDate.startOf("minute");
@@ -115,7 +121,7 @@ const CreateTournamentForm: React.FC = () => {
         t("messages.creations_success", { name: data.name }),
         "success"
       );
-      navigate(routePaths.homeRoute, {
+      navigate(`${routePaths.homeRoute}?tab=upcoming`, {
         replace: true,
         state: { refresh: true }
       });
@@ -227,7 +233,7 @@ const CreateTournamentForm: React.FC = () => {
             required
             name="startDate"
             label={t("create_tournament_form.start_date_time")}
-            minDateTime={now}
+            minDateTime={minStartDate}
             format="DD/MM/YYYY HH:mm"
             ampm={false}
             {...(!mobile && {

--- a/frontend/src/components/modules/Tournaments/TournamentListing/TournamentCard.tsx
+++ b/frontend/src/components/modules/Tournaments/TournamentListing/TournamentCard.tsx
@@ -43,6 +43,9 @@ const TournamentCard: React.FC<TournamentCardProps> = ({
 
   const finished = allMatchesPlayed(tournament);
 
+  // Check if the tournament has fewer than 2 players after it started
+  const cancelled = !tournamentHasNotStarted && tournament.players.length < 2;
+
   const handleOpenDialog = (): void => {
     setOpenDialog(true);
   };
@@ -113,13 +116,19 @@ const TournamentCard: React.FC<TournamentCardProps> = ({
               {t("upcoming_tournament_view.tournament_full")}
             </Typography>
           )}
-          {finished && (
-            <Typography color="text.secondary">
-              <strong>
-                {t("frontpage_labels.winner")}:{" "}
-                {findTournamentWinner(tournament)}
-              </strong>
+          {cancelled ? (
+            <Typography color="red">
+              <strong>{t("frontpage_labels.cancelled")}</strong>
             </Typography>
+          ) : (
+            finished && (
+              <Typography color="text.secondary">
+                <strong>
+                  {t("frontpage_labels.winner")}:{" "}
+                  {findTournamentWinner(tournament)}
+                </strong>
+              </Typography>
+            )
           )}
           {(type === "ongoing" || type === "upcoming") && (
             <Typography color="text.secondary">

--- a/frontend/src/context/TournamentsContext.tsx
+++ b/frontend/src/context/TournamentsContext.tsx
@@ -89,10 +89,11 @@ export const TournamentsProvider = (): ReactElement => {
 
   const isInitialRender = useRef(true);
 
+  const doRefresh = (): void => {
+    setShouldRefresh(true); // Use state setter to trigger re-fetching
+  };
+
   useEffect(() => {
-    const doRefresh = (): void => {
-      setShouldRefresh(true);
-    };
     const getAllTournaments = async (): Promise<void> => {
       try {
         const { past, ongoing, upcoming } = await getSortedTournaments();
@@ -102,9 +103,9 @@ export const TournamentsProvider = (): ReactElement => {
           past,
           ongoing,
           upcoming,
-          doRefresh
+          doRefresh // This function can be passed to children to trigger refresh
         }));
-        setShouldRefresh(false);
+        setShouldRefresh(false); // Reset shouldRefresh after fetching
       } catch (error) {
         showToast(t("messages.could_not_fetch_tournaments"), "error");
         setValue((prevValue) => ({
@@ -123,12 +124,11 @@ export const TournamentsProvider = (): ReactElement => {
       isInitialRender.current = false;
     }
 
-    // Fetch the tournaments after creating tournaments or navigatating to location with refresh tag true
+    // Clean up location state without mutating it directly
     if (location.state?.refresh) {
-      void getAllTournaments();
-      location.state.refresh = false;
+      setShouldRefresh(true);
     }
-  }, [location.state]);
+  }, [shouldRefresh, location.state]);
 
   if (value.isLoading) {
     return <Loader />;


### PR DESCRIPTION
Following tickets fixed:

https://trello.com/c/CB8fl13W/37-after-creating-tournament-navigate-to-upcoming-instead-of-ongoing

https://trello.com/c/SWnmboI3/36-after-creating-tournament-instantly-show-created-tournament-without-need-to-refresh-browser

https://trello.com/c/HCcVo9uF/22-after-tournament-has-a-winner-set-it-finished-instead-of-waiting-for-the-ending-date

https://trello.com/c/tcX0pAUa/25-can-add-points-to-player-before-clock-is-started

https://trello.com/c/cDugZMaZ/23-after-tournament-has-started-if-there-are-no-players-finish-it-and-set-it-as-cancelled

https://trello.com/c/oiF37sS1/38-tournaments-can-be-instantly-started-with-setting-start-date-in-the-past