### PR TITLE
Fixed bug with time

### DIFF
--- a/backend/server/src/services/tournamentService.ts
+++ b/backend/server/src/services/tournamentService.ts
@@ -683,7 +683,6 @@ export class TournamentService {
       this.calculateRoundRobinMatches(tournamentDetails.maxPlayers);
     }
 
-    // Validate startDate and endDate
     if (
       tournamentDetails.startDate !== undefined &&
       tournamentDetails.endDate !== undefined
@@ -695,6 +694,16 @@ export class TournamentService {
         throw new BadRequestError({
           message:
             "Invalid tournament dates. The start date must be before the end date."
+        });
+      }
+
+      const now = new Date();
+
+      // Check if start date and time is before the current date and time
+      if (startDate < now) {
+        throw new BadRequestError({
+          message:
+            "Invalid tournament date. The start date and time cannot be in the past."
         });
       }
     }

--- a/backend/server/src/services/tournamentService.ts
+++ b/backend/server/src/services/tournamentService.ts
@@ -343,6 +343,13 @@ export class TournamentService {
     userId: string,
     creatorId: string
   ): Promise<void> {
+    // Check if the userId is provided
+    if (!userId || userId.trim() === "") {
+      throw new BadRequestError({
+        message: "Player must be selected before proceeding with withdrawal."
+      });
+    }
+
     const tournament = await TournamentModel.findById(tournamentId).exec();
     if (tournament === null || tournament === undefined) {
       throw new NotFoundError({
@@ -361,7 +368,6 @@ export class TournamentService {
     const matches = await MatchModel.find({ tournamentId }).exec();
 
     const currentTime = new Date();
-
     for (const match of matches) {
       // Only modify if there is no winner or end timestamp, so only the unfinished matches
       if (match.winner === undefined && match.endTimestamp === undefined) {

--- a/frontend/i18n.ts
+++ b/frontend/i18n.ts
@@ -1,10 +1,10 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
-import enTranslation from "./locales/en.json"; 
+import enTranslation from "./locales/en.json";
 import fiTranslation from "./locales/fi.json";
 
-(async () => {
+void (async () => {
   try {
     await i18n
       .use(initReactI18next) // passes i18n down to react-i18next

--- a/frontend/src/components/modules/Tournaments/TournamentListing/TournamentCard.tsx
+++ b/frontend/src/components/modules/Tournaments/TournamentListing/TournamentCard.tsx
@@ -124,20 +124,44 @@ const TournamentCard: React.FC<TournamentCardProps> = ({
           {(type === "ongoing" || type === "upcoming") && (
             <Typography color="text.secondary">
               {t("frontpage_labels.start_date")}:{" "}
-              {new Date(tournament.startDate).toLocaleDateString("fi")}
+              {new Date(tournament.startDate).toLocaleString("fi", {
+                hour: "2-digit",
+                minute: "2-digit",
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit"
+              })}
             </Typography>
           )}
           {(type === "ongoing" || type === "upcoming") && (
             <Typography color="text.secondary">
               {t("frontpage_labels.end_date")}:{" "}
-              {new Date(tournament.endDate).toLocaleDateString("fi")}
+              {new Date(tournament.endDate).toLocaleString("fi", {
+                hour: "2-digit",
+                minute: "2-digit",
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit"
+              })}
             </Typography>
           )}
           {type === "past" && (
             <Typography color="text.secondary">
               {`${tournament.location}, 
-              ${new Date(tournament.startDate).toLocaleDateString("fi")} -
-              ${new Date(tournament.endDate).toLocaleDateString("fi")}`}
+              ${new Date(tournament.startDate).toLocaleString("fi", {
+                hour: "2-digit",
+                minute: "2-digit",
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit"
+              })} -
+              ${new Date(tournament.endDate).toLocaleString("fi", {
+                hour: "2-digit",
+                minute: "2-digit",
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit"
+              })}`}
             </Typography>
           )}
         </CardContent>


### PR DESCRIPTION
Fixed the bug with the editing time of tournament in the past and bug that user could press button to withdraw a player without choosing any. And also displayed time of the tournament on the main page.
Fixed ticket:
https://trello.com/c/FQFBz1U8/32-edit-problem-with-tournaments
https://trello.com/c/1VGOBtTM/33-problem-with-allowing-to-withdraw-player-without-actually-selecting-one