### PR TITLE
fix: add point buttons now have corresponding player names

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -56,8 +56,8 @@
     "reset_roles": "Reset official roles"
   },
   "buttons": {
-    "add_point_player_1": "Add point for player 1",
-    "add_point_player_2": "Add point for player 2",
+    "add_point_player_1": "Add point for",
+    "add_point_player_2": "Add point for",
     "ok_button": "OK",
     "close_button": "Close",
     "start_timer": "Start",

--- a/frontend/locales/fi.json
+++ b/frontend/locales/fi.json
@@ -56,8 +56,8 @@
     "reset_roles": "Nollaa toimitsijaroolit"
   },
   "buttons": {
-    "add_point_player_1": "Lisää piste pelaajalle 1",
-    "add_point_player_2": "Lisää piste pelaajalle 2",
+    "add_point_player_1": "Lisää piste",
+    "add_point_player_2": "Lisää piste",
     "ok_button": "OK",
     "close_button": "Sulje",
     "start_timer": "Aloita",

--- a/frontend/src/components/modules/GameInterface/GameInterface.tsx
+++ b/frontend/src/components/modules/GameInterface/GameInterface.tsx
@@ -849,6 +849,8 @@ const GameInterface: React.FC = () => {
                   handleOpen={handleOpen}
                   handleClose={handleClose}
                   gameStarted={matchInfo.startTimestamp !== undefined}
+                  player1name={matchInfo.firstNames[0]}
+                  player2name={matchInfo.firstNames[1]}
                 />
               )}
             <br></br>

--- a/frontend/src/components/modules/GameInterface/OfficialButtons.tsx
+++ b/frontend/src/components/modules/GameInterface/OfficialButtons.tsx
@@ -19,6 +19,8 @@ interface AddPointDialogProps {
   handleOpen: (player: number) => void;
   handleClose: () => void;
   gameStarted: boolean;
+  player1name: string;
+  player2name: string;
 }
 
 const OfficialButtons: React.FC<AddPointDialogProps> = ({
@@ -28,7 +30,9 @@ const OfficialButtons: React.FC<AddPointDialogProps> = ({
   handlePointShowing,
   handleOpen,
   handleClose,
-  gameStarted
+  gameStarted,
+  player1name,
+  player2name
 }) => {
   const { t } = useTranslation();
 
@@ -42,7 +46,7 @@ const OfficialButtons: React.FC<AddPointDialogProps> = ({
           variant="contained"
           disabled={!gameStarted}
         >
-          {t("buttons.add_point_player_1")}
+          {`${t("buttons.add_point_player_1")} ${player1name}`}
         </Button>
         <Button
           onClick={() => {
@@ -51,7 +55,7 @@ const OfficialButtons: React.FC<AddPointDialogProps> = ({
           variant="contained"
           disabled={!gameStarted}
         >
-          {t("buttons.add_point_player_2")}
+          {`${t("buttons.add_point_player_2")} ${player2name}`}
         </Button>
       </Box>
       <Dialog open={open} onClose={handleClose}>


### PR DESCRIPTION
The "Add points" buttons should now show corresponding player names